### PR TITLE
Efficiency update for client status

### DIFF
--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -57,23 +57,17 @@ ptc_status <- active_list %>%
 
 # split out the clients with ph entries
 clients_in_ph <- ptc_status %>%
-  group_by(PersonalID) %>%
-  arrange(desc(PTCStatus)) %>%
-  slice(1L) %>%
   filter(PTCStatus == "PH") %>%
-  ungroup() %>%
-  mutate(InPH = 1) %>%
-  select(PersonalID, InPH)
+  select(1) %>%
+  distinct() %>%
+  mutate(InPH = 1)
 
 # split out the clients with lh entries
 clients_in_lh <- ptc_status %>%
-  group_by(PersonalID) %>%
-  arrange(PTCStatus) %>%
-  slice(1L) %>%
   filter(PTCStatus == "LH") %>%
-  ungroup() %>%
-  mutate(LH = 1) %>%
-  select(PersonalID, LH)
+  select(1) %>%
+  distinct() %>%
+  mutate(LH = 1)
 
 # join them back, with one row per client, create PTCStatus variable
 client_ptc_status <- clients_in_lh %>%


### PR DESCRIPTION
This is a minor change that handles the splitting out of LH and PH clients in fewer lines. On my system this also runs a tiny bit faster--the timing code below gives me 0.44 seconds for the old code and 0.09 seconds for the new code. Verified that old and new code produce the same results, just not in the same order (old code is ordered by client ID, doesn't seem to be necessary so I didn't include it in the new code but could be added back in).

```
library(tictoc)

tic("old")
clients_in_lh <- ptc_status %>%
  group_by(PersonalID) %>%
  arrange(PTCStatus) %>%
  slice(1L) %>%
  filter(PTCStatus == "LH") %>%
  ungroup() %>%
  mutate(LH = 1) %>%
  select(PersonalID, LH)
toc()

tic("new")
clients_in_lh_test <- ptc_status %>%
  filter(PTCStatus == "LH") %>%
  select(1) %>%
  distinct() %>%
  mutate(LH = 1)
toc()
```