### PR TITLE
Deduplicating Summary Tables

### DIFF
--- a/00_cohorts.R
+++ b/00_cohorts.R
@@ -75,6 +75,7 @@ co_hohs_served <-  Enrollment %>%
   select(all_of(vars_we_want))
 
 summary_hohs_served <- co_hohs_served %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(hohs_served = n())
 
@@ -88,6 +89,7 @@ co_hohs_served_leavers <-  Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_hohs_served_leavers <- co_hohs_served_leavers %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(hohs_served_leavers = n())
 
@@ -102,6 +104,7 @@ co_hohs_served_leavers_died <- Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_hohs_served_leavers_died  <- co_hohs_served_leavers_died  %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(hohs_served_leavers_died = n())
 
@@ -112,6 +115,7 @@ co_clients_served <-  Enrollment %>%
   select(all_of(vars_we_want))
 
 summary_clients_served <- co_clients_served %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(clients_served = n())
 
@@ -123,6 +127,7 @@ co_adults_served <-  Enrollment %>%
   select(all_of(vars_we_want))
 
 summary_adults_served <- co_adults_served %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(adults_served = n())
 
@@ -135,6 +140,7 @@ co_adults_entered <-  Enrollment %>%
   select(all_of(vars_we_want))
 
 summary_adults_entered <- co_adults_entered %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(adults_entered = n())
 
@@ -148,6 +154,7 @@ co_hohs_entered <- Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_hohs_entered <- co_hohs_entered %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(hohs_entered = n())
 
@@ -160,6 +167,7 @@ co_clients_moved_in <-  Enrollment %>%
   select(all_of(vars_we_want))
 
 summary_clients_moved_in <- co_clients_moved_in %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(clients_moved_in = n())
 
@@ -171,6 +179,7 @@ co_adults_moved_in <-  Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_adults_moved_in <- co_adults_moved_in %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(adults_moved_in = n())
 
@@ -182,6 +191,7 @@ co_clients_moved_in_leavers <-  Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_clients_moved_in_leavers <- co_clients_moved_in_leavers %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(clients_moved_in_leavers = n())
 
@@ -194,6 +204,7 @@ co_hohs_moved_in_leavers <-  Enrollment %>%
   select(all_of(vars_we_want))	
 
 summary_hohs_moved_in_leavers <- co_hohs_moved_in_leavers %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(hohs_moved_in_leavers = n())
 
@@ -206,6 +217,7 @@ co_adults_moved_in_leavers <-  Enrollment %>%
   select(all_of(vars_we_want)) 
 
 summary_adults_moved_in_leavers <- co_adults_moved_in_leavers %>%
+  distinct(PersonalID, ProjectName) %>%
   group_by(ProjectName) %>%
   summarise(adults_moved_in_leavers = n())
 

--- a/04_DataQuality.R
+++ b/04_DataQuality.R
@@ -1925,23 +1925,6 @@ check_eligibility <- served_in_date_range %>%
     
     rm(IncomeBenefits, smallIncome)
     
-    # Servide End Date Does Not Match Start Date
-    service_end_date_error <- served_in_date_range %>%
-      inner_join(Services %>%
-                   filter((ymd(ServiceStartDate) != ymd(ServiceEndDate) |
-                             is.na(ServiceEndDate)) &
-                            Description != "Emergency Shelter") %>%
-                   select(-PersonalID), 
-                 by = "EnrollmentID") %>%
-      mutate(
-        Issue = "Service End Date Does Not Match Start Date",
-        Type = "Warning",
-        Guidance = "At least one of the services recorded in this entry for this 
-        client has a end date that is either missing or does not match the service 
-        start date. Please adjust or enter the end date so it matches the start date."
-      ) %>%
-      select(all_of(vars_we_want))
-    
     # Non HoHs w Svcs or Referrals --------------------------------------------
     # SSVF projects should be showing this as an Error, whereas non-SSVF projects
     # should be showing it as a warning, and only back to Feb of 2018.
@@ -2467,7 +2450,6 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       path_status_determination,
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
-      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       spdat_on_non_hoh,
@@ -2938,7 +2920,6 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
       served_in_date_range,
-      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       smallProject,

--- a/04_DataQuality.R
+++ b/04_DataQuality.R
@@ -1925,6 +1925,23 @@ check_eligibility <- served_in_date_range %>%
     
     rm(IncomeBenefits, smallIncome)
     
+    # Servide End Date Does Not Match Start Date
+    service_end_date_error <- served_in_date_range %>%
+      inner_join(Services %>%
+                   filter((ymd(ServiceStartDate) != ymd(ServiceEndDate) |
+                             is.na(ServiceEndDate)) &
+                            Description != "Emergency Shelter") %>%
+                   select(-PersonalID), 
+                 by = "EnrollmentID") %>%
+      mutate(
+        Issue = "Service End Date Does Not Match Start Date",
+        Type = "Warning",
+        Guidance = "At least one of the services recorded in this entry for this 
+        client has a end date that is either missing or does not match the service 
+        start date. Please adjust or enter the end date so it matches the start date."
+      ) %>%
+      select(all_of(vars_we_want))
+    
     # Non HoHs w Svcs or Referrals --------------------------------------------
     # SSVF projects should be showing this as an Error, whereas non-SSVF projects
     # should be showing it as a warning, and only back to Feb of 2018.
@@ -2450,6 +2467,7 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       path_status_determination,
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
+      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       spdat_on_non_hoh,
@@ -2920,6 +2938,7 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
       served_in_date_range,
+      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       smallProject,


### PR DESCRIPTION
Minor addition to the summary tables to enable deduplicated head of household counts. All the filtering logic is done by the summarizing point, so I just added a distinct() line to each. Runtime on this is comparable to previous runtime, perhaps a bit shorter.