### PR TITLE
Minor Active_List Updates

### DIFF
--- a/04_DataQuality.R
+++ b/04_DataQuality.R
@@ -1925,23 +1925,6 @@ check_eligibility <- served_in_date_range %>%
     
     rm(IncomeBenefits, smallIncome)
     
-    # Servide End Date Does Not Match Start Date
-    service_end_date_error <- served_in_date_range %>%
-      inner_join(Services %>%
-                   filter((ymd(ServiceStartDate) != ymd(ServiceEndDate) |
-                             is.na(ServiceEndDate)) &
-                            Description != "Emergency Shelter") %>%
-                   select(-PersonalID), 
-                 by = "EnrollmentID") %>%
-      mutate(
-        Issue = "Service End Date Does Not Match Start Date",
-        Type = "Warning",
-        Guidance = "At least one of the services recorded in this entry for this 
-        client has a end date that is either missing or does not match the service 
-        start date. Please adjust or enter the end date so it matches the start date."
-      ) %>%
-      select(all_of(vars_we_want))
-    
     # Non HoHs w Svcs or Referrals --------------------------------------------
     # SSVF projects should be showing this as an Error, whereas non-SSVF projects
     # should be showing it as a warning, and only back to Feb of 2018.
@@ -2467,7 +2450,6 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       path_status_determination,
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
-      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       spdat_on_non_hoh,
@@ -2938,7 +2920,6 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
       served_in_date_range,
-      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       smallProject,

--- a/04_DataQuality.R
+++ b/04_DataQuality.R
@@ -1925,6 +1925,23 @@ check_eligibility <- served_in_date_range %>%
     
     rm(IncomeBenefits, smallIncome)
     
+    # Servide End Date Does Not Match Start Date
+    service_end_date_error <- served_in_date_range %>%
+      inner_join(Services %>%
+                   filter((ymd(ServiceStartDate) != ymd(ServiceEndDate) |
+                             is.na(ServiceEndDate)) &
+                            Description != "Emergency Shelter") %>%
+                   select(-PersonalID), 
+                 by = "EnrollmentID") %>%
+      mutate(
+        Issue = "Service End Date Does Not Match Start Date",
+        Type = "Warning",
+        Guidance = "At least one of the services recorded in this entry for this 
+        client has a end date that is either missing or does not match the service 
+        start date. Please adjust or enter the end date so it matches the start date."
+      ) %>%
+      select(all_of(vars_we_want))
+    
     # Non HoHs w Svcs or Referrals --------------------------------------------
     # SSVF projects should be showing this as an Error, whereas non-SSVF projects
     # should be showing it as a warning, and only back to Feb of 2018.
@@ -2450,6 +2467,7 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       path_status_determination,
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
+      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       spdat_on_non_hoh,
@@ -2920,6 +2938,7 @@ unsheltered_by_month <- unsheltered_enrollments %>%
       referrals_on_hh_members,
       referrals_on_hh_members_ssvf,
       served_in_date_range,
+      service_end_date_error,
       services_on_hh_members,
       services_on_hh_members_ssvf,
       smallProject,

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -116,8 +116,7 @@ active_list <- active_list %>%
   mutate(
     RelationshipToHoH = if_else(is.na(RelationshipToHoH), 99, RelationshipToHoH),
     hoh = if_else(str_detect(HouseholdID, fixed("s_")) |
-           (str_detect(HouseholdID, fixed("h_")) &
-              RelationshipToHoH == 1), 1, 0)) 
+              RelationshipToHoH == 1, 1, 0)) 
 
 # what household ids exist if we only count those with a hoh?
 HHIDs_in_current_logic <- active_list %>% 

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -358,10 +358,8 @@ active_list <- county %>%
   left_join(Enrollment %>%
               select(EnrollmentID, UserCreating), by = "EnrollmentID") %>%
   mutate(
-    UserID = gsub(pattern = '[^0-9\\.]', '', UserCreating, perl = TRUE),
-    UserCreating = str_remove(UserCreating, "\\(.*\\)"),
-    UserID = as.numeric(UserID)
-  ) %>%
+    UserID = as.numeric(gsub(pattern = '[^0-9\\.]', '', UserCreating, perl = TRUE))
+    ) %>%
   left_join(Users %>%
               select(UserID, UserCounty), by = "UserID") %>%
   mutate(CountyServed = if_else(CountyServed == "MISSING County" &

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -321,11 +321,8 @@ disability_data <- active_list %>%
   group_by(HouseholdID) %>%
   mutate(
     CountyServed = if_else(is.na(CountyServed), "MISSING County", CountyServed),
-    DisablingCondition = if_else(DisablingCondition == 1, 100, DisablingCondition),
-    DisabilityInHH = max(DisablingCondition),
-    DisablingCondition = if_else(DisablingCondition == 100, 1, DisablingCondition),
-    DisabilityInHH = if_else(DisabilityInHH == 100, 1, 0),
-    TAY = if_else(max(AgeAtEntry) < 25, 1, 0),
+    DisabilityInHH = max(if_else(DisablingCondition == 1, 1, 0)),
+    TAY = if_else(max(AgeAtEntry) < 25 & max(AgeAtEntry) >= 16, 1, 0),
     PHTrack = if_else(
       !is.na(PHTrack) &
         !is.na(ExpectedPHDate) &

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -385,15 +385,13 @@ income_data <- active_list %>%
       ),
     by = c("PersonalID", "EnrollmentID")
   ) %>%
-  mutate(DateCreated = ymd_hms(DateCreated)) %>%
+  mutate(DateCreated = ymd_hms(DateCreated),
+         IncomeFromAnySource = if_else(is.na(IncomeFromAnySource),
+                                       99,
+                                       IncomeFromAnySource)) %>%
   group_by(PersonalID, EnrollmentID) %>%
-  mutate(
-    MaxUpdate = max(DateCreated),
-    IncomeFromAnySource = if_else(is.na(IncomeFromAnySource),
-                                  99,
-                                  IncomeFromAnySource)
-  ) %>%
-  filter(MaxUpdate == DateCreated) %>%
+  arrange(desc(DateCreated)) %>%
+  slice(1L) %>%
   ungroup() %>%
   select(PersonalID,
          EnrollmentID,


### PR DESCRIPTION
When I originally updated the TAY logic in `cohorts`, I didn't realize the same logic was used in `active_list`. This updates the `active_list` TAY logic to bring it in line with our earlier change, and compresses the logic checking whether there is a known disability in the household down to a single line instead of four.