### PR TITLE
move in date logic adjustments

### DIFF
--- a/00_get_Export_and_ART.R
+++ b/00_get_Export_and_ART.R
@@ -300,12 +300,11 @@ Enrollment <- Enrollment %>%
   left_join(small_project, by = "ProjectID") %>%
   left_join(HHEntry, by = "HouseholdID") %>%
   mutate(
-    MoveInDateAdjust = case_when(
-      !is.na(HHMoveIn) &
-        ymd(HHMoveIn) <= ymd(ExitAdjust) &
-        ymd(EntryDate) <= ymd(HHMoveIn) ~ HHMoveIn,
-      !is.na(HHMoveIn) &
-        ymd(HHMoveIn) <= ymd(ExitAdjust) ~ EntryDate), 
+    MoveInDateAdjust = if_else(!is.na(HHMoveIn) &
+                                 ymd(HHMoveIn) <= ymd(ExitAdjust),
+                               if_else(ymd(EntryDate) <= ymd(HHMoveIn),
+                                       HHMoveIn, EntryDate),
+                               NA_real_), 
     EntryAdjust = case_when(
       ProjectType %in% c(1, 2, 4, 8, 12) ~ EntryDate,
       ProjectType %in% c(3, 9, 13) &

--- a/00_get_Export_and_ART.R
+++ b/00_get_Export_and_ART.R
@@ -261,42 +261,51 @@ rm(small_exit)
 small_project <- Project %>%
   select(ProjectID, ProjectType, ProjectName) 
 
-# getting HoH's Entry Dates bc WS is using that to overwrite MoveIn Dates
+# getting HH information
 # only doing this for RRH and PSHs since Move In Date doesn't matter for ES, etc.
-HoHsEntry <- Enrollment %>%
+HHMoveIn <- Enrollment %>%
   left_join(small_project, by = "ProjectID") %>%
-  filter(RelationshipToHoH == 1 &
-           ProjectType %in% c(3, 9, 13)) %>%
-  select(HouseholdID, "HoHsEntry" = EntryDate, "HoHsMoveIn" = MoveInDate) %>%
+  filter(ProjectType %in% c(3, 9, 13)) %>%
+  mutate(
+    ValidMoveIn = case_when(
+      # prior to 2017, PSH didn't use move-in dates, so we're overwriting 
+      # those PSH move-in dates with the Entry Date        
+      (ymd(EntryDate) < mdy("10012017") &
+         ProjectType %in% c(3, 9))  ~ EntryDate,
+      # the Move-In Dates must fall between the Entry and ExitAdjust to be 
+      # considered valid
+      ymd(EntryDate) <= ymd(MoveInDate) & 
+        ymd(MoveInDate) <= ymd(ExitAdjust)
+      ~ MoveInDate
+    )
+  ) %>%
+  filter(!is.na(ValidMoveIn)) %>%
+  group_by(HouseholdID) %>%
+  mutate(HHMoveIn = min(ValidMoveIn)) %>%
+  ungroup() %>%
+  select(HouseholdID, HHMoveIn) %>%
   unique()
 
-## ^^ this code causes a duplication for situations where a hh has two clients
-# marked as Head of Household AND the HoHs have different Entry Dates. RARE,
-# but possible. Not sure how to fix this, maybe it's just something to know.
+HHEntry <- Enrollment %>%
+  left_join(small_project, by = "ProjectID") %>%
+  group_by(HouseholdID) %>%
+  mutate(FirstEntry = min(EntryDate)) %>%
+  ungroup() %>%
+  select(HouseholdID, "HHEntry" = FirstEntry) %>%
+  unique() %>%
+  left_join(HHMoveIn, by = "HouseholdID")
+
 
 Enrollment <- Enrollment %>%
   left_join(small_project, by = "ProjectID") %>%
-  left_join(HoHsEntry, by = "HouseholdID") %>%
+  left_join(HHEntry, by = "HouseholdID") %>%
   mutate(
     MoveInDateAdjust = case_when(
-      !is.na(HoHsMoveIn) &
-        # prior to 2017, PSH didn't use move-in dates, so we're overwriting 
-        # those PSH move-in dates with the Entry Date        
-        (ymd(EntryDate) < mdy("10012017") &
-           ProjectType %in% c(3, 9)) |
-      # meant to account for non-hohs that join later
-        (ymd(EntryDate) > ymd(HoHsEntry) &
-           ProjectType %in% c(3, 9, 13)) ~ EntryDate,
-      ((
-        ymd(EntryDate) >= mdy("10012017") &
-          ProjectType %in% c(3, 9)
-      ) | ProjectType == 13) &
-        # the Move-In Dates must fall between the Entry and ExitAdjust to be 
-        # considered valid
-        ymd(EntryDate) <= ymd(MoveInDate) & 
-        ymd(MoveInDate) <= ymd(ExitAdjust)
-      ~ MoveInDate
-    ), 
+      !is.na(HHMoveIn) &
+        ymd(HHMoveIn) <= ymd(ExitAdjust) &
+        ymd(EntryDate) <= ymd(HHMoveIn) ~ HHMoveIn,
+      !is.na(HHMoveIn) &
+        ymd(HHMoveIn) <= ymd(ExitAdjust) ~ EntryDate), 
     EntryAdjust = case_when(
       ProjectType %in% c(1, 2, 4, 8, 12) ~ EntryDate,
       ProjectType %in% c(3, 9, 13) &
@@ -304,7 +313,7 @@ Enrollment <- Enrollment %>%
     )
   )
 
-rm(small_project, HoHsEntry)
+rm(small_project, HHEntry)
 
 # Client Location
 


### PR DESCRIPTION
This code should resolve #81, which was looking at move-in date issues. Added bonus, it fixes the rare issue of duplicating household information when we have two heads of household with different entry dates by treating households as units instead of relying on the entered head of household relationships. The general idea behind this code (copied from issue) is:

> start with a column modification that leaves us with only the move-in dates we KNOW for each individual entry based on the export (keeps only move-in dates between entry and adjusted exit, adds move-in dates for those old housing projects, removes move-in dates for projects that shouldn't have them)
> - call it known_move_in for now
> 
> find the earliest known_move_in in each household
> - call it first_known_move_in for now
> 
> for any household members who
> 1) have no known_move_in
> 2) AND are in a household that has a first_known_move_in,
> 
> THEN set their move-in date to either their entry date or the household's first_known_move_in, whichever is later.
> 
> (At first I had a third logical condition on that third step that looked at program type, but if we start by cleaning up the move-in dates in the first step then program is functionally checked by the second logical condition)
> If one or both conditions is not matched, keep whatever date or null value was already in the known_move_in column for that person

I have 79 entries that are handled differently with this new code. Here are a few examples of those changes; just let me know if you want the whole list!

- 97195 and 176524 both entered after their respective heads of household and before the household move in, but their entry date was used as their move in date with the original code. Their move in dates now match those on the entries of their heads of household
- 22651 has an move in date in their entry, but it wasn't applying to the household members with the original code because their move in dates hadn't been updated from an old entry. The modified code applies the head of household's move in date instead of the old dates
- 228729 has a move in date, but it wasn't copied to their partner with the original code because neither person is marked head of household. The modified code copies that move in date to their partner
- all four household members joining 69696 a week after their entry have a move in date imputed with the old code, but the household never had any move-ins entered. No one in the household has a move in date with the modified code
- 209161's household entered before move in dates were used for PSH, but the old code doesn't treat the entry dates as move-in dates. The modified code gives them all move in dates based on their entry time frame.


In the original issue, we were using h_320104, h_333368, h_338026, and h_299765 as validation checks. The h_333368 and h_338026 households were fixed with the code that was pushed in response to the original issue, but h_320104 and h_299765 were still showing up incorrectly. These modifications also correctly handle the issues with those last two households.