### PR TITLE
Minor Adjustments for Future Exits

### DIFF
--- a/00_get_Export_and_ART.R
+++ b/00_get_Export_and_ART.R
@@ -275,7 +275,9 @@ small_exit <- Exit %>% select(EnrollmentID,
                               OtherDestination)
 
 Enrollment <- left_join(Enrollment, small_exit, by = "EnrollmentID") %>%
-  mutate(ExitAdjust = if_else(is.na(ExitDate), today(), ExitDate))
+  mutate(ExitAdjust = if_else(is.na(ExitDate) |
+                                ExitDate > today(),
+                              today(), ExitDate))
 
 rm(small_exit)
 

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -23,7 +23,8 @@ load("images/COHHIOHMIS.RData")
 # clients currently entered into a homeless project in our system
 
 co_currently_homeless <- co_clients_served %>%
-  filter(is.na(ExitDate) &
+  filter((is.na(ExitDate) |
+            ExitDate > today()) &
            (ProjectType %in% c(4, lh_project_types) |
               (
                 ProjectType %in% c(ph_project_types) &


### PR DESCRIPTION
Two small changes that fix #85!

Discussion from issues:

> Description from GB: When the active list filters just for clients that are currently homeless, it's checking for null exit dates. There's ~25 folks with future exit dates, so I went and spot-checked some of their audit records. It looks like they're mostly year errors (like they exited at the end of 2019, but the data was entered in 2020 and folks just entered 2020 by default).
> 
> Discussion from Slack: Added a check for this in the Data Quality reporting but also we should include these clients since technically speaking, HMIS thinks those clients are still in that program. (Returning user-entered data back to them.)

Neither of these affect the added data quality check, as that still runs on the original exit date. I extended this to include an `ExitAdjust` change in the `get_Export` code because we're using that variable for things like length of stay and aged into chronicity calculations.