### PR TITLE
Add environment binding locks to prevent re-assignment

### DIFF
--- a/00_cohorts.R
+++ b/00_cohorts.R
@@ -32,7 +32,10 @@ library(tidyverse)
 library(lubridate)
 library(HMIS)
 
-if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
+if (!exists("Enrollment")) {
+  load("images/COHHIOHMIS.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 ReportStart <- ymd(calc_data_goes_back_to)
 ReportEnd <- ymd(meta_HUDCSV_Export_End)

--- a/00_daily_update.R
+++ b/00_daily_update.R
@@ -160,26 +160,28 @@ COHHIO_HMIS <- environment()
 source("00_get_Export_and_ART.R", local = COHHIO_HMIS)
 
 increment("working on Cohorts")
-Cohorts <- rlang::child_env(COHHIO_HMIS)
+Cohorts <- rlang::env(COHHIO_HMIS)
+rlang::env_binding_lock(COHHIO_HMIS, ls(COHHIO_HMIS))
 source("00_cohorts.R", local = Cohorts)
+rlang::env_binding_lock(Cohorts, ls(Cohorts))
 
 increment("working on Bed_Unit_Utilization")
-source("01_Bed_Unit_Utilization.R", local = rlang::child_env(Cohorts))
+source("01_Bed_Unit_Utilization.R", local = rlang::env(Cohorts))
 
 increment("working on QPR_SPDATs")
-source("02_QPR_SPDATs.R", local = rlang::child_env(COHHIO_HMIS))
+source("02_QPR_SPDATs.R", local = rlang::env(COHHIO_HMIS))
 
 increment("working on QPR_EEs")
-source("02_QPR_EEs.R", local = rlang::child_env(Cohorts))
+source("02_QPR_EEs.R", local = rlang::env(Cohorts))
 
 increment("working on Veterans")
-source("03_Veterans.R", local = rlang::child_env(Cohorts))
+source("03_Veterans.R", local = rlang::env(Cohorts))
 
 increment("working on Data Quality")
-source("04_DataQuality.R", local = rlang::child_env(Cohorts))
+source("04_DataQuality.R", local = rlang::env(Cohorts))
 
 increment("working on Project Evaluation")
-source("05_Veterans_Active_List.R", local = rlang::child_env(Cohorts))
+source("05_Veterans_Active_List.R", local = rlang::env(Cohorts))
 
 # rm(list = ls())
 # 
@@ -190,10 +192,10 @@ increment("working on SPMs")
 source("07_SPMs.R", local = new.env())
 
 increment("working on Active List")
-source("08_Active_List.R", local = rlang::child_env(Cohorts))
+source("08_Active_List.R", local = rlang::env(Cohorts))
 
 increment("copying images to app directories")
-source("00_copy_images.R", local = rlang::child_env(Cohorts))
+source("00_copy_images.R", local = new.env())
 
 increment("Done! All images are updated.")
 

--- a/01_Bed_Unit_Utilization.R
+++ b/01_Bed_Unit_Utilization.R
@@ -18,7 +18,10 @@ library(scales)
 library(HMIS)
 
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 
 # despite the fact we're pulling in usually more than 2 years of data, the 

--- a/02_QPR_EEs.R
+++ b/02_QPR_EEs.R
@@ -20,7 +20,10 @@ library(janitor)
 library(HMIS)
 
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 rm(Affiliation, CaseManagers, Disabilities, EmploymentEducation, EnrollmentCoC, 
    Exit, Export, Funder, HealthAndDV, Offers, ProjectCoC, Scores, VeteranCE, 

--- a/02_QPR_SPDATs.R
+++ b/02_QPR_SPDATs.R
@@ -23,7 +23,10 @@ library(janitor)
 library(HMIS)
 
 # loading the COHHIOHMIS data, dropping unnecessary objects
-if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
+if (!exists("Enrollment")) {
+  load("images/COHHIOHMIS.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 
 rm(Affiliation, CaseManagers, Client, EnrollmentCoC, EmploymentEducation, 

--- a/03_Veterans.R
+++ b/03_Veterans.R
@@ -17,7 +17,10 @@ library(lubridate)
 library(HMIS)
 
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 rm(Affiliation, Disabilities, EmploymentEducation, EnrollmentCoC, Exit,
    Export, Funder, HealthAndDV, IncomeBenefits, Offers, Organization, 

--- a/04_DataQuality.R
+++ b/04_DataQuality.R
@@ -20,7 +20,10 @@ library(HMIS)
 e <- environment()
 source("04_Guidance.R", local = e)
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 va_funded <- Funder %>%
   filter(Funder %in% c(27, 30, 33, 37:42, 45)) %>%

--- a/05_Veterans_Active_List.R
+++ b/05_Veterans_Active_List.R
@@ -17,7 +17,10 @@ library(lubridate)
 library(HMIS)
 
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 # Get all veterans and associated hh members ------------------------------
 

--- a/08_Active_List.R
+++ b/08_Active_List.R
@@ -20,7 +20,10 @@ library(plotly)
 library(HMIS)
 
 if (!exists("Enrollment")) load("images/COHHIOHMIS.RData")
-if (!exists("tay")) load("images/cohorts.RData")
+if (!exists("tay")) {
+  load("images/cohorts.RData")
+  rlang::env_binding_lock(environment(), ls())
+}
 
 # clients currently entered into a homeless project in our system
 


### PR DESCRIPTION
### 00_daily_updates
 - now locks the variables in the `COHHIO_HMIS` & `Cohorts` environments such they are not reassigned in subsequent scripts

### all others
 - Other scripts lock all variables in the environment after loading the `RData` files such that if there is an attempt to overwrite a locked object, an error will be encountered.