### PR TITLE
Reduce rds size by rendering gg_plot to images and handling function environments

### DIFF
--- a/00_copy_images.R
+++ b/00_copy_images.R
@@ -93,7 +93,7 @@ data_prep <- function(nms,
       # Write the images
       purrr::imap(~ {
         message(paste0("Saving ", .y, ".jpg"))
-        .p <- file.path(dir,  "inst", "app", "www", paste0(.y, ".jpg"))
+        .p <- file.path(dir,  purrr::when(grepl("Rminor$", dir), . ~ c("inst", "app", "www"), ~ "www"), paste0(.y, ".jpg"))
         ggplot2::ggsave(.p, .x, width = 800 / 72, height = 500 / 72, dpi = "screen", device = "jpeg", units = "in")
         file.path("www", basename(.p))
       })

--- a/00_copy_images.R
+++ b/00_copy_images.R
@@ -93,7 +93,7 @@ data_prep <- function(nms,
       # Write the images
       purrr::imap(~ {
         message(paste0("Saving ", .y, ".jpg"))
-        .p <- file.path(dir,  purrr::when(grepl("Rminor$", dir), . ~ c("inst", "app", "www"), ~ "www"), paste0(.y, ".jpg"))
+        .p <- file.path(dir,  purrr::when(grepl("Rminor$", dir), . ~ file.path("inst", "app", "www"), ~ "www"), paste0(.y, ".jpg"))
         ggplot2::ggsave(.p, .x, width = 800 / 72, height = 500 / 72, dpi = "screen", device = "jpeg", units = "in")
         file.path("www", basename(.p))
       })

--- a/00_daily_update.R
+++ b/00_daily_update.R
@@ -23,7 +23,7 @@
 
 # clearing the environment prior to running all the scripts
 rm(list = ls())
-
+library(dplyr)
 # some preliminary parameters
 
 stop_with_instructions <- function(...) {
@@ -78,10 +78,11 @@ increment <- function(..., cenv = rlang::caller_env()) {
                                     step = cenv$.step, 
                                     msg = paste0(...)))
   }
-  if (stringr::str_detect(paste0(...),"^Done!")) {
+  if (stringr::str_detect(paste0(...),"Done!")) {
+    cli::cat_boxx(cli::col_blue("Completed at ", Sys.time(),"\nTiming data saved to ", .lt_path), border_style = "single", padding  = 1, margin = 0, float = "center") 
     cli::cli_process_done(cenv$.update)
     saveRDS(cenv$.timer, .lt_path)
-    cli::col_blue("Timing data saved to ", .lt_path)
+    
     return(.lt_path)
   }
   # If no previous timer data, just give the elapsed time
@@ -116,10 +117,10 @@ increment <- function(..., cenv = rlang::caller_env()) {
     archive::archive_extract(zip_file, "data")
     file.remove(zip_file)
   } else if (ncol(readr::read_csv("data/Client.csv")) != 33 &&
-             read_csv("data/Export.csv",
+             readr::read_csv("data/Export.csv",
                       col_types = c("iicccccccTDDcciii")) %>%
-             mutate(ExportEndDate = ymd(ExportEndDate)) %>%
-             pull(ExportEndDate) != Sys.Date()) {
+             dplyr::mutate(ExportEndDate = lubridate::ymd(ExportEndDate)) %>%
+             dplyr::pull(ExportEndDate) != Sys.Date()) {
     stop_with_instructions("Please download the HUD CSV Export to the data/ folder.")
   }
   


### PR DESCRIPTION
To remedy the unnecessarily large size of the rds file there are now mechanisms to explicitly set the function environment as the `baseenv` for the feather accessor functions to eliminate serialization of unneeded environments
- and - 
 to render large ggplot objects (>30MB) to images for display in the app. 
The ggplot images are saved to _inst/app/www_ on Rminor and _www_ on Rminor_elevated..
