### PR TITLE
Edits to Support RMinor Elevated updates

### DIFF
--- a/05_Veterans_Active_List.R
+++ b/05_Veterans_Active_List.R
@@ -221,10 +221,32 @@ hh_size <- active_list %>%
   unique() %>%
   count(HouseholdID)
 
-veteran_active_list <- active_list %>%
+veteran_active_list_enrollments <- active_list %>%
   filter(VeteranStatus == 1) %>%
   left_join(hh_size, by = "HouseholdID") %>%
   rename("HouseholdSize" = n) %>%
+  mutate(EnrollType = case_when(
+    ProjectType %in% lh_project_types ~ 1,
+    ProjectType %in% ph_project_types ~ 2,
+    TRUE ~ 3
+  )) %>%
+  group_by(PersonalID, EnrollType) %>%
+  arrange(desc(EntryDate)) %>%
+  slice(1L) %>%
+  ungroup()
+
+lh_veteran_active_list_enrollments <- veteran_active_list_enrollments %>%
+  filter(ProjectType %in% lh_project_types)
+
+ph_veteran_active_list_enrollments <- veteran_active_list_enrollments %>%
+  filter(ProjectType %in% ph_project_types)
+
+o_veteran_active_list_enrollments <- veteran_active_list_enrollments %>%
+  filter(!ProjectType %in% lh_project_types &
+           !ProjectType %in% ph_project_types)
+
+veteran_active_list <- lh_veteran_active_list_enrollments
+
   left_join(most_recent_offer, by = "PersonalID") %>%
   left_join(small_CLS, by = "PersonalID") %>%
   mutate(
@@ -292,26 +314,26 @@ veteran_active_list <- active_list %>%
   left_join(responsible_providers, by = "County") %>%
   unique()
 
-veteran_active_list_display <- veteran_active_list %>%
-  select(PersonalID,
-         HOMESID,
-         DateVeteranIdentified,
-         ListStatus,
-         VAEligible,
-         SSVFIneligible,
-         County,
-         PHTrack,
-         ExpectedPHDate,
-         Eligibility,
-         ActiveDateDisplay,
-         ActiveDate,
-         DaysActive,
-         HouseholdSize,
-         MostRecentOffer,
-         HousingPlan,
-         SSVFServiceArea) %>%
-  left_join(small_ees, by = "PersonalID") %>%
-  unique()
+# veteran_active_list_display <- veteran_active_list %>%
+#   select(PersonalID,
+#          HOMESID,
+#          DateVeteranIdentified,
+#          ListStatus,
+#          VAEligible,
+#          SSVFIneligible,
+#          County,
+#          PHTrack,
+#          ExpectedPHDate,
+#          Eligibility,
+#          ActiveDateDisplay,
+#          ActiveDate,
+#          DaysActive,
+#          HouseholdSize,
+#          MostRecentOffer,
+#          HousingPlan,
+#          SSVFServiceArea) %>%
+#   left_join(small_ees, by = "PersonalID") %>%
+#   unique()
 
 # Currently Homeless Vets -------------------------------------------------
 

--- a/05_Veterans_Active_List.R
+++ b/05_Veterans_Active_List.R
@@ -208,19 +208,21 @@ small_ees <- vet_ees %>%
 
 # stayers & people who exited in the past 90 days to a temp destination
 
-hh_size <- vet_ees %>%
-  select(HouseholdID, PersonalID) %>%
-  unique() %>%
-  count(HouseholdID)
-
-veteran_active_list <- vet_ees %>%
+active_list <- vet_ees %>%
   filter(!PersonalID %in% c(currently_housed_in_psh_rrh) &
-           VeteranStatus == 1 &
            (is.na(ExitDate) |
               (
                 !Destination %in% c(perm_destinations) &
                   ymd(ExitDate) >= today() - days(90)
-              ))) %>%
+              )))
+
+hh_size <- active_list %>%
+  select(HouseholdID, PersonalID) %>%
+  unique() %>%
+  count(HouseholdID)
+
+veteran_active_list <- active_list %>%
+  filter(VeteranStatus == 1) %>%
   left_join(hh_size, by = "HouseholdID") %>%
   rename("HouseholdSize" = n) %>%
   left_join(most_recent_offer, by = "PersonalID") %>%


### PR DESCRIPTION
All these changes are just structural edits to support the changes I talked about in the other PR. Basically, I'm pulling out the most recent enrollment of each type, taking the original table and grabbing the most recent information in it (for things like active status and identification date), then joining in the three program types I separated out. This reshaping lets us display the relevant enrollments in a single row and avoids the ambiguity of having multiple sets of status information!