### PR TITLE
Adding chronic determination to VBNL

### DIFF
--- a/00_functions.R
+++ b/00_functions.R
@@ -397,6 +397,7 @@ chronic_determination <- function(.data, aged_in = FALSE) {
                                                         ChronicStatus)),
                ChronicStatus = factor(
                  ChronicStatus,
+                 ordered = TRUE,
                  levels = chronicity_levels)))
   }
   

--- a/00_functions.R
+++ b/00_functions.R
@@ -336,12 +336,16 @@ freeze_pe <- function(dir, overwrite = FALSE) {
 }
 
 
-chronic_determination <- function(.data) { 
+chronic_determination <- function(.data, aged_in = FALSE) { 
   
   needed_cols <- c("PersonalID", "EntryDate",
                    "AgeAtEntry", "DisablingCondition",
                    "DateToStreetESSH", "TimesHomelessPastThreeYears",
                    "MonthsHomelessPastThreeYears", "ExitAdjust", "ProjectType")
+  
+  chronicity_levels <- if(aged_in) {
+    c("Chronic", "Aged In", "Nearly Chronic", "Not Chronic")}
+  else {c("Chronic", "Nearly Chronic", "Not Chronic")}
   
   if (all((needed_cols) %in% colnames(.data))) {
     return(
@@ -387,13 +391,13 @@ chronic_determination <- function(.data) {
                      DisablingCondition == 1 &
                      !is.na(DisablingCondition) ~ "Nearly Chronic",
                    TRUE ~ "Not Chronic"),
+               ChronicStatus = case_when(aged_in ~ ChronicStatus,
+                                         TRUE ~ if_else(ChronicStatus == "Aged In",
+                                                        "Chronic",
+                                                        ChronicStatus)),
                ChronicStatus = factor(
                  ChronicStatus,
-                 levels = c(
-                   "Chronic",
-                   "Aged In",
-                   "Nearly Chronic",
-                   "Not Chronic"))))
+                 levels = chronicity_levels)))
   }
   
   else {

--- a/05_Veterans_Active_List.R
+++ b/05_Veterans_Active_List.R
@@ -310,6 +310,9 @@ veteran_active_list <- veteran_active_list_enrollments %>%
   left_join(small_CLS, by = "PersonalID") %>%
   left_join(hoh_chronicity, by = "PersonalID") %>%
   mutate(
+    ChronicStatus = if_else(!is.na(HoHChronicStatus) &
+                            HoHChronicStatus < ChronicStatus, 
+                          HoHChronicStatus, ChronicStatus),
     ActiveDateDisplay = paste0(ActiveDate,
                                "<br>(",
                                difftime(today(), ymd(ActiveDate)),


### PR DESCRIPTION
For this, I just used the chronic logic from the active list because we've already gone over it with fine-toothed combs! The primary difference here is that it's based on each individual, with no consideration of the rest of the household, so we can skip ahead to using the SinglyChronic logic as an independent determinant and put the whole status in a single case statement (neat!). I use the most recent entry information for this to keep it consistent with where we're pulling the rest of the person-level information like eligibility and housing track.

I haven't removed your thought process notes about chronicity in the following section because I didn't know if moving the logic in cohorts was still on the table...it feels like it might be less necessary now? But didn't want to make that call, so I left the notes alone. Let me know what you think!